### PR TITLE
Fix PR runs

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,7 @@ set -e
 # (including submodules) on publish, so we have to re-clone our own repository
 # to get the Aseprite submodule we plan to build.
 
-git clone --config remote.origin.fetch=+$NEOMURA_SETUP_ASEPRITE_CLI_ACTION_REF https://github.com/$NEOMURA_SETUP_ASEPRITE_CLI_ACTION_REPOSITORY --depth 1 clone
+git clone https://github.com/$NEOMURA_SETUP_ASEPRITE_CLI_ACTION_REPOSITORY --config remote.origin.fetch=+refs/*:refs/remotes/origin/* --branch $NEOMURA_SETUP_ASEPRITE_CLI_ACTION_REF --depth 1 clone
 
 cd clone
 git submodule update --init --recursive submodules/aseprite/aseprite

--- a/build.sh
+++ b/build.sh
@@ -4,10 +4,7 @@ set -e
 # (including submodules) on publish, so we have to re-clone our own repository
 # to get the Aseprite submodule we plan to build.
 
-NEOMURA_SETUP_ASEPRITE_CLI_ACTION_BRANCH=${NEOMURA_SETUP_ASEPRITE_CLI_ACTION_REF#refs/heads/}
-NEOMURA_SETUP_ASEPRITE_CLI_ACTION_BRANCH=${NEOMURA_SETUP_ASEPRITE_CLI_ACTION_BRANCH#refs/tags/}
-
-git clone https://github.com/$NEOMURA_SETUP_ASEPRITE_CLI_ACTION_REPOSITORY --branch $NEOMURA_SETUP_ASEPRITE_CLI_ACTION_BRANCH --depth 1 clone
+git clone --config remote.origin.fetch=+$NEOMURA_SETUP_ASEPRITE_CLI_ACTION_REF https://github.com/$NEOMURA_SETUP_ASEPRITE_CLI_ACTION_REPOSITORY --depth 1 clone
 
 cd clone
 git submodule update --init --recursive submodules/aseprite/aseprite

--- a/build.sh
+++ b/build.sh
@@ -4,9 +4,14 @@ set -e
 # (including submodules) on publish, so we have to re-clone our own repository
 # to get the Aseprite submodule we plan to build.
 
-git clone https://github.com/$NEOMURA_SETUP_ASEPRITE_CLI_ACTION_REPOSITORY --config remote.origin.fetch=+refs/*:refs/remotes/origin/* --branch $NEOMURA_SETUP_ASEPRITE_CLI_ACTION_REF --depth 1 clone
-
+mkdir clone
 cd clone
+
+git init
+git remote add origin https://github.com/$NEOMURA_SETUP_ASEPRITE_CLI_ACTION_REPOSITORY
+git fetch origin $NEOMURA_SETUP_ASEPRITE_CLI_ACTION_REF:temp
+git checkout temp
+
 git submodule update --init --recursive submodules/aseprite/aseprite
 cd ..
 


### PR DESCRIPTION
The hack currently in place to pull down the appropriate branch doesn't work when there _is_ no branch, such as when GitHub creates a temporary ref to represent the result of merging a PR.