### PR TITLE
Fix Windows build reliability

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -27,6 +27,14 @@ fi
 cmake -E make_directory build
 cmake -E chdir build cmake -G Ninja -DENABLE_UI=OFF ../clone/submodules/aseprite/aseprite
 cd build
-ninja
+
+if [ "$(uname)" == "Darwin" ]; then
+  ninja
+elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+  ninja
+else
+  ninja -j 1
+fi
+
 
 echo "$PWD/bin" >> $GITHUB_PATH


### PR DESCRIPTION
Looks like Windows builds are quite unreliable.  Appears to be a parallelism issue with Ninja.

I can't imagine many people are using this with Windows build agents, but for them, we should resolve this.